### PR TITLE
Add go get instructions, could be confusing for developers new to go

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Return the information for the Person
 
 ## Demo
 
+Make sure you have iglo installed in the GOPATH
+```bash 
+$ cd $GOPATH
+$ go get github.com/subosito/iglo
+```
+
 You can go to the `examples` directory and then run the `api-server.go`.
 
 ```bash


### PR DESCRIPTION
When running the example with iglo installed at GOPATH, it can be confusing to developers unfamiliar with golang.

``` bash
stage:examples khangtoh$ go run api-server.go 
api-server.go:4:2: cannot find package "github.com/subosito/iglo" in any of:
    /usr/local/go/src/pkg/github.com/subosito/iglo (from $GOROOT)
    /Users/khangtoh/go/src/github.com/subosito/iglo (from $GOPATH)
stage:examples khangtoh$ 
```

Add instructions for go get
