### PR TITLE
Fix unmarshaling of Parameter.Values

### DIFF
--- a/iglo.go
+++ b/iglo.go
@@ -41,13 +41,17 @@ type Model struct {
 }
 
 type Parameter struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Type        string   `json:"type"`
-	Required    bool     `json:"required"`
-	Default     string   `json:"default"`
-	Example     string   `json:"example"`
-	Values      []string `json:"values"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Type        string  `json:"type"`
+	Required    bool    `json:"required"`
+	Default     string  `json:"default"`
+	Example     string  `json:"example"`
+	Values      []Value `json:"values"`
+}
+
+type Value struct {
+	Value string `json:"value"`
 }
 
 type Example struct {


### PR DESCRIPTION
When using the extended [value syntax for parameter specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#description-11), the JSON that is generated for the Parameter.Values field is not a `[]string` but an array of further JSON objects (using [this sample template](https://github.com/danielgtaylor/aglio/blob/master/example.md)).

``` json
{
  "name": "sort",
  "description": "Which field to sort by",
  "type": "string",
  "required": false,
  "default": "",
  "example": "joined",
  "values": [
    {
      "value": "name"
    },
    {
      "value": "joined"
    },
    {
      "value": "-joined"
    }
  ]
}
```
