### PR TITLE
Support for new warnings structure in v2.3.0-pre.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 before_install:
   - git clone --recursive git://github.com/apiaryio/drafter.git
   - cd drafter
-  - git checkout v2.0.1
+  - git checkout v2.3.0-pre.2
   - ./configure
   - make drafter
   - export PATH=$PWD/bin:$PATH

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -148,5 +148,5 @@ var dummyAPI = &API{
 		Message:  "",
 		Location: make([]string, 0),
 	},
-	Warnings: make([]string, 0),
+	Warnings: []Warning{},
 }

--- a/iglo.go
+++ b/iglo.go
@@ -1,10 +1,21 @@
 package iglo
 
 type API struct {
-	Version  string   `json:"_version"`
-	AST      AST      `json:"ast"`
-	Error    Error    `json:"error"`
-	Warnings []string `json:"warnings"`
+	Version  string    `json:"_version"`
+	AST      AST       `json:"ast"`
+	Error    Error     `json:"error"`
+	Warnings []Warning `json:"warnings"`
+}
+
+type Warning struct {
+	Code     int        `json:"code"`
+	Message  string     `json:"message"`
+	Location []Location `json:"location"`
+}
+
+type Location struct {
+	Index  int `json:"index"`
+	Length int `json:"length"`
 }
 
 type Error struct {

--- a/iglo_test.go
+++ b/iglo_test.go
@@ -21,7 +21,7 @@ func TestDrafterVersion(t *testing.T) {
 		panic(err)
 	}
 
-	expected := []byte("v2.0.1\n")
+	expected := []byte("v2.3.0-pre.2\n")
 	if !reflect.DeepEqual(output, expected) {
 		t.Errorf("Expected:\n%+v\nActual:\n%+v", string(expected), string(output))
 	}

--- a/parser.go
+++ b/parser.go
@@ -13,13 +13,9 @@ import (
 )
 
 func ParseJSON(r io.Reader) (*API, error) {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
 	api := new(API)
-	err = json.Unmarshal(b, &api)
+	err := json.NewDecoder(r).Decode(&api)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Warnings from drafter now contains objects with a structure looking like this:

```
    {
      "code": 8,
      "message": "parameter 'id' not specified in 'Update' its '/update' URI template",
      "location": [
        {
          "index": 248,
          "length": 109
        }
      ]
    }
```

I also replaced the use of `ioutil.ReadAll` + `json.Unmarshal` with `json.NewDecoder(r).Decode(&api)`
